### PR TITLE
Added `wmi_exporter_force_package` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ wmi_exporter_extra_flags:
 ```
 
 Whether to ignore existing choco installation and force 'package' type installation. Defaults to `false`.
-```yml
-wmi_exporter_force_package:
-```
 
+```yml
+wmi_exporter_force_package: false
+```
 
 ### Global Variable
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Allows passing full CLI flags. Defaults to an empty string.
 wmi_exporter_extra_flags:
 ```
 
+Whether to ignore existing choco installation and force 'package' type installation. Defaults to `false`.
+```yml
+wmi_exporter_force_package:
+```
+
+
 ### Global Variable
 
 #### Proxy

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,9 @@ wmi_exporter_extra_flags:
 # Download directory for the wmi export installations files.
 wmi_exporter_download_directory: "{{ ansible_env.TEMP }}\\wmi_exporter"
 
+# Whether to force installation by package, i.e ignore existing choco
+wmi_exporter_force_package: false
+
 # If a proxy is in use this information can be used.
 # By default, proxy settings are taken from the default_* variables,
 # if they are not defined they are ignored.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
     - name: 'main : set install type choco'
       set_fact:
         wmi_exporter_install_type: 'choco'
-      when: register_wmi_exporter_choco_check.stat.exists
+      when: register_wmi_exporter_choco_check.stat.exists and not wmi_exporter_force_package
 
     - name: 'main : include install type'
       include_tasks: 'install/{{ var_filename }}.yml'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,8 @@
     - name: 'main : set install type choco'
       set_fact:
         wmi_exporter_install_type: 'choco'
-      when: register_wmi_exporter_choco_check.stat.exists and not wmi_exporter_force_package
+      when: register_wmi_exporter_choco_check.stat.exists and
+            not wmi_exporter_force_package
 
     - name: 'main : include install type'
       include_tasks: 'install/{{ var_filename }}.yml'


### PR DESCRIPTION
Added a variable which allows a user to force the role to use the package-style installation,
even if the Chocolatey binary is found.