### PR TITLE
argument MetricsPath should only be included if var wmi_exporter_metrics_path is defined

### DIFF
--- a/tasks/install/choco.yml
+++ b/tasks/install/choco.yml
@@ -15,7 +15,7 @@
     - arguments: '/ListenPort={{ wmi_exporter_listen_port }}'
       condition: '{{ wmi_exporter_listen_port }}'
     - arguments: '/MetricsPath={{ wmi_exporter_metrics_path }}'
-      condition: '{{ wmi_exporter_listen_port }}'
+      condition: '{{ wmi_exporter_metrics_path }}'
     - arguments: '/TextFileDir={{ wmi_exporter_textfile_dir }}'
       condition: '{{ wmi_exporter_textfile_dir }}'
     - arguments: '/ExtraFlags={{ wmi_exporter_extra_flags }}'

--- a/tasks/install/package.yml
+++ b/tasks/install/package.yml
@@ -34,7 +34,7 @@
     - arguments: 'LISTEN_PORT={{ wmi_exporter_listen_port }}'
       condition: '{{ wmi_exporter_listen_port }}'
     - arguments: 'METRICS_PATH={{ wmi_exporter_metrics_path }}'
-      condition: '{{ wmi_exporter_listen_port }}'
+      condition: '{{ wmi_exporter_metrics_path }}'
     - arguments: 'TEXTFILE_DIR={{ wmi_exporter_textfile_dir }}'
       condition: '{{ wmi_exporter_textfile_dir }}'
     - arguments: 'EXTRA_FLAGS={{ wmi_exporter_extra_flags }}'


### PR DESCRIPTION
Previously, MetricsPath was included if wmi_exporter_listen_port was defined.  I presume this reflects the intent.