### PR TITLE
Make package installation follow redirects

### DIFF
--- a/tasks/install/package.yml
+++ b/tasks/install/package.yml
@@ -12,6 +12,7 @@
     dest: '{{ wmi_exporter_download_directory }}\\wmi_exporter.msi'
     proxy_url: '{{ wmi_exporter_proxy }}'
     validate_certs: '{{ wmi_exporter_validate_certs }}'
+    follow_redirects: all
   vars:
     var_url: '{{ var_url_base }}/releases/download//v{{ wmi_exporter_version }}/'
     var_url_base: https://github.com/martinlindhe/wmi_exporter


### PR DESCRIPTION
I was having problems with package installation resulting in a `wmi_exporter.msi` file containing
an HTML body saying "you are being redirected" rather than the MSI installer expected.

Making this change in my local version of this role fixed the issue for me.