### PR TITLE
Add Feature: Local download of windows_exporter.msi (wmi_exporter_local_download)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 and [human-readable changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 1.3.1
+
+### Fixed
+
+- Add `wmi_exporter_local_download` when downloading the msi package, to allow downloading locally.
+
 ## 1.3.0
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Whether to ignore existing choco installation and force 'package' type installat
 wmi_exporter_force_package: false
 ```
 
-# Download the file on the local end, only used if not installing using choco. Defaults to `false`.
+Download the file on the local end, only used if not installing using choco. Defaults to `false`.
 
 ```yml
 wmi_exporter_local_download: false

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ Whether to ignore existing choco installation and force 'package' type installat
 wmi_exporter_force_package: false
 ```
 
+Whether to download the package file locally rather than on the remote end
+Only used if not installing using choco. Defaults to `false`.
+
+```yml
+wmi_exporter_local_download: false
+```
+
 ### Global Variable
 
 #### Proxy

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ wmi_exporter_architecture: amd64
 
 Windows installation parameters for the wmi_exporter. [Link](https://github.com/martinlindhe/wmi_exporter#installation)
 
-As the `--collectors.enabled` flag, provide a comma-separated list of enabled collectors
+As the `--collectors.enabled` flag, provide a comma-separated list of enabled collectors.
 
 ```yml
 wmi_exporter_enabled_collectors:
@@ -56,7 +56,7 @@ The path at which to serve metrics. Defaults to `/metrics`
 wmi_exporter_metrics_path:
 ```
 
-As the `--collector.textfile.directory` flag, provide a directory to read text files with metrics from
+As the `--collector.textfile.directory` flag, provide a directory to read text files with metrics from.
 
 ```yml
 wmi_exporter_textfile_dir:
@@ -74,8 +74,7 @@ Whether to ignore existing choco installation and force 'package' type installat
 wmi_exporter_force_package: false
 ```
 
-Whether to download the package file locally rather than on the remote end
-Only used if not installing using choco. Defaults to `false`.
+# Download the file on the local end, only used if not installing using choco. Defaults to `false`.
 
 ```yml
 wmi_exporter_local_download: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for sbaerlocher.wmi_exporter
 
 # The latest version of the wmi_exporter is automatically
-# calculated if 'wmi_exporter_version' no set.
+# calculated if 'wmi_exporter_version' is not set.
 # wmi_exporter_version: 0.13.0
 
 # Architecture of the wmi exporter to be installed.
@@ -37,7 +37,7 @@ wmi_exporter_download_directory: "{{ ansible_env.TEMP }}\\wmi_exporter"
 # Whether to force installation by package, i.e ignore existing choco
 wmi_exporter_force_package: false
 
-# Download the file on the local end, used if not installing using choco
+# Download the file on the local end, only used if not installing using choco
 wmi_exporter_local_download: false
 
 # If a proxy is in use this information can be used.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,9 @@ wmi_exporter_download_directory: "{{ ansible_env.TEMP }}\\wmi_exporter"
 # Whether to force installation by package, i.e ignore existing choco
 wmi_exporter_force_package: false
 
+# Download the file on the local end, used if not installing using choco
+wmi_exporter_local_download: false
+
 # If a proxy is in use this information can be used.
 # By default, proxy settings are taken from the default_* variables,
 # if they are not defined they are ignored.

--- a/tasks/install/package.yml
+++ b/tasks/install/package.yml
@@ -67,3 +67,10 @@
     state: present
     wait: true
     arguments: '{{ arguments | default(omit) }}'
+
+- name: 'package : cleanup temp dir (localhost)'
+  file:
+    path: "{{ tmpdir_installer.path }}"
+    state: absent
+  delegate_to: localhost
+  when: wmi_exporter_local_download is defined

--- a/tasks/install/package.yml
+++ b/tasks/install/package.yml
@@ -42,7 +42,14 @@
     win_copy:
       src: '{{ tmpdir_installer.path }}/{{ var_url_file }}'
       dest: '{{ wmi_exporter_download_directory }}\\wmi_exporter.msi'
-  when: wmi_exporter_local_download
+  always:
+  - name: 'package : cleanup temp dir (localhost)'
+    file:
+      path: "{{ tmpdir_installer.path }}"
+      state: absent
+    delegate_to: localhost
+  when: wmi_exporter_local_download is defined
+
 
 - name: 'package : create package arguments'
   set_fact:
@@ -70,10 +77,3 @@
     state: present
     wait: true
     arguments: '{{ arguments | default(omit) }}'
-
-- name: 'package : cleanup temp dir (localhost)'
-  file:
-    path: "{{ tmpdir_installer.path }}"
-    state: absent
-  delegate_to: localhost
-  when: wmi_exporter_local_download is defined

--- a/tasks/install/package.yml
+++ b/tasks/install/package.yml
@@ -14,7 +14,7 @@
     validate_certs: '{{ wmi_exporter_validate_certs }}'
     follow_redirects: all
   vars:
-    var_url: '{{ var_url_base }}/releases/download//v{{ wmi_exporter_version }}/'
+    var_url: '{{ var_url_base }}/releases/download/v{{ wmi_exporter_version }}'
     var_url_base: https://github.com/prometheus-community/windows_exporter
     var_url_file: 'windows_exporter-{{ wmi_exporter_version }}-{{ wmi_exporter_architecture }}.msi'
   when: not wmi_exporter_local_download
@@ -32,16 +32,16 @@
       dest: '{{ tmpdir_installer.path }}/wmi_exporter.msi'
       proxy_url: '{{ wmi_exporter_proxy }}'
       validate_certs: '{{ wmi_exporter_validate_certs }}'
-    vars:
-      var_url: '{{ var_url_base }}/releases/download//v{{ wmi_exporter_version }}/'
-      var_url_base: https://github.com/prometheus-community/windows_exporter
-      var_url_file: 'windows_exporter-{{ wmi_exporter_version }}-{{ wmi_exporter_architecture }}.msi'
     delegate_to: localhost
     register: register_wmi_exporter_local_package
   - name: 'package : copy file to remote node'
     win_copy:
-      src: '{{ tmpdir_installer.path }}/{{ var_url_file }}'
+      src: '{{ tmpdir_installer.path }}/wmi_exporter.msi'
       dest: '{{ wmi_exporter_download_directory }}\\wmi_exporter.msi'
+  vars:
+    var_url: '{{ var_url_base }}/releases/download/v{{ wmi_exporter_version }}'
+    var_url_base: https://github.com/prometheus-community/windows_exporter
+    var_url_file: 'windows_exporter-{{ wmi_exporter_version }}-{{ wmi_exporter_architecture }}.msi'
   when: wmi_exporter_local_download
 
 - name: 'package : create package arguments'

--- a/tasks/install/package.yml
+++ b/tasks/install/package.yml
@@ -21,34 +21,34 @@
 
 - name: 'package : downloading on localhost'
   block:
-  - name: 'package : create temp directory (localhost)'
-    tempfile:
-      state: directory
-    register: tmpdir_installer
-    delegate_to: localhost
-  - name: 'package : download wmi_exporter (localhost)'
-    get_url:
-      url: '{{ var_url }}/{{ var_url_file }}'
-      dest: '{{ tmpdir_installer.path }}/wmi_exporter.msi'
-      proxy_url: '{{ wmi_exporter_proxy }}'
-      validate_certs: '{{ wmi_exporter_validate_certs }}'
-    delegate_to: localhost
-    register: register_wmi_exporter_local_package
-  - name: 'package : copy file to remote node'
-    win_copy:
-      src: '{{ tmpdir_installer.path }}/wmi_exporter.msi'
-      dest: '{{ wmi_exporter_download_directory }}\\wmi_exporter.msi'
+    - name: 'package : create temp directory (localhost)'
+      tempfile:
+        state: directory
+      register: tmpdir_installer
+      delegate_to: localhost
+    - name: 'package : download wmi_exporter (localhost)'
+      get_url:
+        url: '{{ var_url }}/{{ var_url_file }}'
+        dest: '{{ tmpdir_installer.path }}/wmi_exporter.msi'
+        proxy_url: '{{ wmi_exporter_proxy }}'
+        validate_certs: '{{ wmi_exporter_validate_certs }}'
+      delegate_to: localhost
+      register: register_wmi_exporter_local_package
+    - name: 'package : copy file to remote node'
+      win_copy:
+        src: '{{ tmpdir_installer.path }}/wmi_exporter.msi'
+        dest: '{{ wmi_exporter_download_directory }}\\wmi_exporter.msi'
   always:
-  - name: 'package : cleanup temp dir (localhost)'
-    file:
-      path: "{{ tmpdir_installer.path }}"
-      state: absent
-    delegate_to: localhost
+    - name: 'package : cleanup temp dir (localhost)'
+      file:
+        path: "{{ tmpdir_installer.path }}"
+        state: absent
+      delegate_to: localhost
   vars:
     var_url: '{{ var_url_base }}/releases/download/v{{ wmi_exporter_version }}'
     var_url_base: https://github.com/prometheus-community/windows_exporter
     var_url_file: 'windows_exporter-{{ wmi_exporter_version }}-{{ wmi_exporter_architecture }}.msi'
-  when: wmi_exporter_local_download is defined
+  when: wmi_exporter_local_download
 
 - name: 'package : create package arguments'
   set_fact:

--- a/tasks/install/package.yml
+++ b/tasks/install/package.yml
@@ -17,6 +17,29 @@
     var_url: '{{ var_url_base }}/releases/download//v{{ wmi_exporter_version }}/'
     var_url_base: https://github.com/prometheus-community/windows_exporter
     var_url_file: 'windows_exporter-{{ wmi_exporter_version }}-{{ wmi_exporter_architecture }}.msi'
+  when: not wmi_exporter_local_download
+
+- name: 'package : downloading on localhost'
+  block:
+  - name: 'package : create temp directory (localhost)'
+    tempfile:
+      state: directory
+    register: tmpdir_installer
+    delegate_to: localhost
+  - name: 'package : download wmi_exporter (localhost)'
+    get_url:
+      url: '{{ var_url }}/{{ var_url_file }}'
+      dest: '{{ tmpdir_installer.path }}/wmi_exporter.msi'
+      proxy_url: '{{ wmi_exporter_proxy }}'
+      validate_certs: '{{ wmi_exporter_validate_certs }}'
+      follow_redirects: all
+    vars:
+      var_url: '{{ var_url_base }}/releases/download//v{{ wmi_exporter_version }}/'
+      var_url_base: https://github.com/prometheus-community/windows_exporter
+      var_url_file: 'windows_exporter-{{ wmi_exporter_version }}-{{ wmi_exporter_architecture }}.msi'
+    register: register_wmi_exporter_local_package
+  delegate_to: localhost
+  when: wmi_exporter_local_download
 
 - name: 'package : create package arguments'
   set_fact:

--- a/tasks/install/package.yml
+++ b/tasks/install/package.yml
@@ -37,8 +37,12 @@
       var_url: '{{ var_url_base }}/releases/download//v{{ wmi_exporter_version }}/'
       var_url_base: https://github.com/prometheus-community/windows_exporter
       var_url_file: 'windows_exporter-{{ wmi_exporter_version }}-{{ wmi_exporter_architecture }}.msi'
+    delegate_to: localhost
     register: register_wmi_exporter_local_package
-  delegate_to: localhost
+  - name: 'package : copy file to remote node'
+    win_copy:
+      src: '{{ tmpdir_installer.path }}/{{ var_url_file }}'
+      dest: '{{ wmi_exporter_download_directory }}\\wmi_exporter.msi'
   when: wmi_exporter_local_download
 
 - name: 'package : create package arguments'

--- a/tasks/install/package.yml
+++ b/tasks/install/package.yml
@@ -48,7 +48,7 @@
     var_url: '{{ var_url_base }}/releases/download/v{{ wmi_exporter_version }}'
     var_url_base: https://github.com/prometheus-community/windows_exporter
     var_url_file: 'windows_exporter-{{ wmi_exporter_version }}-{{ wmi_exporter_architecture }}.msi'
-  when: wmi_exporter_local_download
+  when: wmi_exporter_local_download | bool
 
 - name: 'package : create package arguments'
   set_fact:

--- a/tasks/install/package.yml
+++ b/tasks/install/package.yml
@@ -32,7 +32,6 @@
       dest: '{{ tmpdir_installer.path }}/wmi_exporter.msi'
       proxy_url: '{{ wmi_exporter_proxy }}'
       validate_certs: '{{ wmi_exporter_validate_certs }}'
-      follow_redirects: all
     vars:
       var_url: '{{ var_url_base }}/releases/download//v{{ wmi_exporter_version }}/'
       var_url_base: https://github.com/prometheus-community/windows_exporter


### PR DESCRIPTION
When working with restrictive environments, the remote end does not always allow external downloads.

This change adds `wmi_exporter_local_download = true` and is backwards compatible.

For your convenience I also updated README/CHANGELOG and bumped minor version.

Feel free to do any changes as you see fit.