### PR TITLE
Choco: use new package name prometheus-windows-exporter.install

### DIFF
--- a/tasks/install/choco.yml
+++ b/tasks/install/choco.yml
@@ -23,7 +23,7 @@
 
 - name: 'choco : install wmi exporter'
   win_chocolatey:
-    name: prometheus-wmi-exporter.install
+    name: prometheus-windows-exporter.install
     proxy_url: '{{ wmi_exporter_proxy }}'
     version: '{{ wmi_exporter_version | default(omit) }}'
     params: '{{ arguments | default(omit) }}'


### PR DESCRIPTION
This was all I needed to do to get it working with Chocolatey...

Thanks for this great project!